### PR TITLE
remove wrong return

### DIFF
--- a/dae_RelayBoard/FTD2XXDllWrap.py
+++ b/dae_RelayBoard/FTD2XXDllWrap.py
@@ -153,8 +153,6 @@ class FTD2XXDllWrap(object):
                 if ret==FT_OK:
                     if idString in SN:
                         return self.FT_Open(i)
-                else:
-                    return (ret, None)
             return (ret, None)
         else:
             return (ret, None)


### PR DESCRIPTION
The function is only checking the first device, if there are more than one device and the DAE you are looking for is not the first device, it returns None. So the else return shall be removed in order to go though all numDevs.