### PR TITLE
Fix FT_handle type to match FTD2XX DLL library

### DIFF
--- a/dae_RelayBoard/FTD2XXDllWrap.py
+++ b/dae_RelayBoard/FTD2XXDllWrap.py
@@ -80,9 +80,9 @@ class FTD2XXDllWrap(object):
         self.FTD2XXDLL = WinDLL("FTD2XX.dll")
  
     def FT_Open(self, deviceNum):
-        handle = c_int()
+        handle = c_void_p()
         ret = self.FTD2XXDLL.FT_Open(deviceNum, pointer(handle))
-        return (ret, handle.value)
+        return (ret, handle)
  
     def FT_Close(self, handle):
         ret = self.FTD2XXDLL.FT_Close(handle)


### PR DESCRIPTION
Hi Peter,

To pursue the discussion we started [here](https://github.com/petersbingham/dae-py-relay-controller/issues/10#issuecomment-738626140) in a more appropriate place:

After some tests, it seems that I struggle to implement a "backward-compatible" solution in which I would first try to use FT_Open as it is currently implemented, and in case of an invalid handle (discovered in following usage of the the DLL library), try to initialize it as I do in my patch: after a FT_Open initializing the handle as something invalid for me, I cannot call the function again (this time with my c_void_p() handle), since I have to FT_Close before ... something that I can't do, since I need a valid handle.

However, during my tests, I discovered that the problem I tried to fix with this patch did not happen on one of my remote computers: I'm not sure if it is because of different driver versions or because this one uses Python 3.8 (the other ones on which current solution failed use latest Python 3.9), but there, the initial code passed.

What is interesting, is that my patch also worked on this computer ... which represents kind of an example of backward compatibility. It is definitely not exhaustive, regarding backward compatibility, but if you have materials to run some tests, I think it's more logical for me to propose that simple two-lines change, as it matches FTD2XX DLL function library (C void pointer used for the handle) and should not have compatibility issues:

![image](https://user-images.githubusercontent.com/23383003/101385712-743b9100-38bc-11eb-94c3-c468131ad547.png)
*(from https://www.ftdichip.com/Support/Documents/ProgramGuides/D2XX_Programmer's_Guide(FT_000071).pdf)*

and:
![image](https://user-images.githubusercontent.com/23383003/101385543-3a6a8a80-38bc-11eb-95ce-51a38d4757f9.png)
*(from https://www.ftdichip.com/Support/Knowledgebase/index.html?ftd2xx_h.htm)*

Regards,

Noël