### PR TITLE
pylibftdi 0.23 returns strings now, not bytes, closes #12

### DIFF
--- a/dae_RelayBoard/FTD2XXLinux.py
+++ b/dae_RelayBoard/FTD2XXLinux.py
@@ -44,11 +44,11 @@ class FTD2XXLinux(object):
             index = 0
             found = False
             for dev in self.driver.list_devices():
-                if re.search(deviceID + '.+', dev[2].decode()):
+                if re.search(deviceID + '.+', dev[2]):
                     if which == index:
                         found = True
-                        print('Found device %s#%d => %s' % (deviceID, index, dev[2].decode()))
-                        deviceID = dev[2].decode()
+                        print('Found device %s#%d => %s' % (deviceID, index, dev[2]))
+                        deviceID = dev[2]
                         break
                     index += 1
 


### PR DESCRIPTION
This works for me on Debian/trixie using pylibftdi v0.24.0, closes #12